### PR TITLE
Fix user delete, remove app invalid value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HOSTNAME=shipa.io
 NAMESPACE=terraform
 NAME=shipa
 BINARY=terraform-provider-${NAME}
-VERSION=0.0.1
+VERSION=0.0.2
 #OS_ARCH=darwin_amd64
 OS_ARCH=linux_amd64
 default: install

--- a/client/apps.go
+++ b/client/apps.go
@@ -34,7 +34,6 @@ type App struct {
 	TeamOwner   string        `json:"teamowner,omitempty"`
 	Plan        *Plan         `json:"plan,omitempty"`
 	Units       []*Unit       `json:"units,omitempty"`
-	Cname       []string      `json:"cname,omitempty"`
 	IP          string        `json:"ip,omitempty"`
 	Org         string        `json:"org,omitempty"`
 	Entrypoints []*Entrypoint `json:"entrypoints,omitempty"`

--- a/client/client.go
+++ b/client/client.go
@@ -214,7 +214,6 @@ func (c *Client) newRequestWithParamsList(method string, payload interface{}, ur
 	if paramsStr != "" {
 		URL = fmt.Sprintf("%s?%s", URL, paramsStr)
 	}
-
 	log.Printf("> %s: %s\n", method, URL)
 
 	if payload != nil {

--- a/client/users.go
+++ b/client/users.go
@@ -1,6 +1,8 @@
 package client
 
-import "errors"
+import (
+	"errors"
+)
 
 type User struct {
 	Email    string `json:"email"`
@@ -37,6 +39,6 @@ func (c *Client) CreateUser(req *User) error {
 }
 
 func (c *Client) DeleteUser(email string) error {
-	params := []*QueryParam{{Key: "email", Val: email}}
+	params := []*QueryParam{{Key: "user", Val: email}}
 	return c.deleteWithParams(params, apiUsers)
 }

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -5,4 +5,3 @@
 # .tfstate files
 *.tfstate
 *.tfstate.*
-var.tfvars

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,13 +1,16 @@
 terraform {
   required_providers {
     shipa = {
-      version = "0.0.1"
+      version = "0.0.2"
       source = "shipa.io/terraform/shipa"
     }
   }
 }
 
-provider "shipa" {}
+provider "shipa" {
+  host = var.shipa_host
+  token = var.shipa_token
+}
 
 # Returns specific app
 data "shipa_app" "app" {

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -6,3 +6,9 @@ variable "cluster_ca_path" {
 
 variable "cluster_address" {
 }
+
+variable "shipa_host" {
+}
+
+variable "shipa_token" {
+}


### PR DESCRIPTION
Fixes:
- app doesn't contain Cname field
fixes `Error: Invalid address to set: []string{"app", "0", "cname"}`

- user call was using wrong field