### PR TITLE
[SHIPA-2502] Use json for app deploy request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHIPA_LOCAL_PROVIDER_NAMESPACE=terraform.local/local/shipa
-VERSION=0.0.8
+VERSION=0.0.9
 BINARY=terraform-provider-shipa_v${VERSION}
 default: install
 

--- a/client/client.go
+++ b/client/client.go
@@ -51,7 +51,7 @@ func apiRoleUser(role string) string {
 }
 
 func apiLogin(host string, user string) string {
-    return fmt.Sprintf("%s/%s/%s/tokens", host, apiUsers, user)
+	return fmt.Sprintf("%s/%s/%s/tokens", host, apiUsers, user)
 }
 
 type Client struct {
@@ -155,7 +155,7 @@ func (c *Client) authenticate() error {
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("could not retrieve token for %s", c.AdminEmail)
 	}
-	
+
 	defer resp.Body.Close()
 	var data map[string]interface{}
 	err = json.NewDecoder(resp.Body).Decode(&data)

--- a/helper/converter_test.go
+++ b/helper/converter_test.go
@@ -57,7 +57,7 @@ func TestNestedStruct(t *testing.T) {
 	}
 	actual := string(data)
 	log.Println(actual)
-	expected := `{"shipa_pool":"test","resources":{"general":{"setup":{"default":false,"public":true},"plan":{"name":"dev"},"security":{"disable_scan":true,"scan_platform_layers":false},"access":{"append":["dev","test"]},"router":"traefik","app_quota":{"limit":"1"}}}}`
+	expected := `{"shipaFramework":"test","resources":{"general":{"setup":{"default":false,"public":true},"plan":{"name":"dev"},"security":{"disableScan":true,"scanPlatformLayers":false},"access":{"append":["dev","test"]},"router":"traefik","appQuota":{"limit":"1"}}}}`
 	if expected != actual {
 		t.Error("json matching failed")
 	}
@@ -184,10 +184,10 @@ func TestConvertStructWithMap(t *testing.T) {
 }
 
 func TestConvertTerraformWithMap(t *testing.T) {
-	expected := `{"matchlabels":{"label_1":"test","label_2":"test"}}`
+	expected := `{"matchLabels":{"label_1":"test","label_2":"test"}}`
 	source := []interface{}{
 		map[string]interface{}{
-			"matchlabels": map[string]interface{}{
+			"match_labels": map[string]interface{}{
 				"label_1": "test",
 				"label_2": "test",
 			},
@@ -208,7 +208,7 @@ func TestConvertTerraformWithMap(t *testing.T) {
 }
 
 func TestConvertMaps(t *testing.T) {
-	input := `{"matchlabels":{"label_1":"test","label_2":"test"}}`
+	input := `{"matchLabels":{"label_1":"test","label_2":"test"}}`
 
 	object := &client.NetworkPeerSelector{}
 	json.Unmarshal([]byte(input), object)
@@ -217,7 +217,6 @@ func TestConvertMaps(t *testing.T) {
 	log.Println("RAW data:", rawData)
 	data, _ := json.Marshal(rawData)
 	log.Println("JSON from RAW data:", string(data))
-
 
 	object = &client.NetworkPeerSelector{}
 	TerraformToStruct(rawData, object)

--- a/shipa/resource_app_deploy.go
+++ b/shipa/resource_app_deploy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/shipa-corp/terraform-provider-shipa/client"
 	"github.com/shipa-corp/terraform-provider-shipa/helper"
@@ -56,11 +57,24 @@ var (
 					Type:     schema.TypeInt,
 					Optional: true,
 				},
+				"protocol": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice([]string{"TCP", "UDP"}, false),
+				},
 				"detach": {
 					Type:     schema.TypeBool,
 					Optional: true,
 				},
 				"message": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"shipa_yaml": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"origin": {
 					Type:     schema.TypeString,
 					Optional: true,
 				},


### PR DESCRIPTION
Converts incoming HCL to `AppRequest` object to POST as JSON body. Depends on SHIPA-2222. 

Also fixes broken tests.

*TEST*
`make`
`cp -r /Users/<your_user_probably>/.terraform.d/plugins/terraform.local/local/shipa/0.0.9/ /Users/<your_user_probably>/.terraform.d/plugins/shipa.io/terraform/shipa/0.0.9` <- may not be your exact terraform plugin location
`terraform apply <file_similar_to_below>`
```
terraform {
  required_providers {
    shipa = {
      version = "0.0.9"
      source  = "shipa.io/terraform/shipa"
    }
  }
}

provider "shipa" {}

resource "shipa_app" "foobar" {
  app {
    name = "foobar"
    teamowner = "shipa-admin-team"
    framework = "shipa-framework"
  }
}

resource "shipa_app_deploy" "foobar" {
  app = "foobar"
  deploy {
    image = "gcr.io/kubernetes-312803/sample-go-app"
    steps = 4
    step_weight = 20
    step_interval = 10
  }
  depends_on = [shipa_app.foobar]
}
```