### PR TITLE
[SHIPA-2719] Leverages new app deploy API capabililties (deprecates separate app creation)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHIPA_LOCAL_PROVIDER_NAMESPACE=terraform.local/local/shipa
-VERSION=0.0.9
+VERSION=0.0.10
 BINARY=terraform-provider-shipa_v${VERSION}
 default: install
 

--- a/client/apps.go
+++ b/client/apps.go
@@ -201,23 +201,32 @@ func (c *Client) DeleteAppCname(appName string, req *AppCnames) error {
 }
 
 type AppDeploy struct {
-	Image          string `json:"image"`
-	PrivateImage   bool   `json:"private-image,omitempty" terraform:"private_image"`
-	RegistryUser   string `json:"registry-user,omitempty" terraform:"registry_user"`
-	RegistrySecret string `json:"registry-secret,omitempty" terraform:"registry_secret"`
-	Steps          int64  `json:"steps,omitempty"`
-	StepWeight     int64  `json:"step-weight,omitempty" terraform:"step_weight"`
-	StepInterval   int64  `json:"step-interval,omitempty" terraform:"step_interval"`
-	Port           int64  `json:"port,omitempty"`
-	Protocol       string `json:"protocol,omitempty"`
-	Detach         bool   `json:"detach"`
-	Message        string `json:"message,omitempty"`
-	ShipaYaml      string `json:"shipaYaml,omitempty" terraform:"shipa_yaml"`
-	Origin         string `json:"origin,omitempty"`
+	Image          string   `json:"image"`
+	PrivateImage   bool     `json:"private-image,omitempty" terraform:"private_image"`
+	RegistryUser   string   `json:"registry-user,omitempty" terraform:"registry_user"`
+	RegistrySecret string   `json:"registry-secret,omitempty" terraform:"registry_secret"`
+	Framework      string   `json:"framework,omitempty"`
+	Plan           string   `json:"plan,omitempty"`
+	Team           string   `json:"teamowner,omitempty"`
+	Description    string   `json:"description,omitempty"`
+	Router         string   `json:"router,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	Env            []string `json:"env,omitempty"`
+	DependencyFile []string `json:"dependencyFile,omitempty"`
+	Steps          int64    `json:"steps,omitempty"`
+	StepWeight     int64    `json:"step-weight,omitempty" terraform:"step_weight"`
+	StepInterval   int64    `json:"step-interval,omitempty" terraform:"step_interval"`
+	Port           int64    `json:"port,omitempty"`
+	Protocol       string   `json:"protocol,omitempty"`
+	Detach         bool     `json:"detach"`
+	Message        string   `json:"message,omitempty"`
+	ShipaYaml      string   `json:"shipaYaml,omitempty" terraform:"shipa_yaml"`
+	Origin         string   `json:"origin,omitempty"`
 }
 
 // AppDeployRequest represents the JSON body that deploy /app expects
 type AppDeployRequest struct {
+	AppConfig      *AppConfig      `json:"appConfig,omitempty"`
 	Image          string          `json:"image"`
 	Port           *Port           `json:"port,omitempty"`
 	Detach         bool            `json:"detach"`
@@ -226,6 +235,18 @@ type AppDeployRequest struct {
 	Origin         string          `json:"origin,omitempty"`
 	CanarySettings *CanarySettings `json:"canarySettings,omitempty"`
 	ShipaYaml      string          `json:"shipaYaml,omitempty"`
+}
+
+// AppConfig represents the JSON body that deploy /app expects
+type AppConfig struct {
+	Framework      string   `json:"framework"`
+	Plan           string   `json:"plan"`
+	Team           string   `json:"team"`
+	Description    string   `json:"description"`
+	Router         string   `json:"router"`
+	Tags           []string `json:"tags,omitempty"`
+	Env            []string `json:"env,omitempty"`
+	DependencyFile []string `json:"dependencyFile,omitempty"`
 }
 
 // Registry represents the JSON body that deploy /app expects
@@ -259,7 +280,9 @@ func (c *Client) DeployApp(appName string, req *AppDeploy) error {
 }
 
 func getAppDeployRequest(req *AppDeploy) *AppDeployRequest {
-	return &AppDeployRequest{
+	var appConfig AppConfig
+
+	payload := &AppDeployRequest{
 		Image: req.Image,
 		Port: &Port{
 			Number:   int(req.Port),
@@ -280,4 +303,18 @@ func getAppDeployRequest(req *AppDeploy) *AppDeployRequest {
 		ShipaYaml: req.ShipaYaml,
 	}
 
+	if req.Framework != "" || req.Plan != "" || req.Team != "" || req.Description != "" || req.Tags != nil || req.Env != nil || req.DependencyFile != nil {
+		appConfig = AppConfig{
+			Framework:      req.Framework,
+			Plan:           req.Plan,
+			Team:           req.Team,
+			Description:    req.Description,
+			Tags:           req.Tags,
+			Env:            req.Env,
+			DependencyFile: req.DependencyFile,
+		}
+		payload.AppConfig = &appConfig
+	}
+
+	return payload
 }

--- a/client/apps_test.go
+++ b/client/apps_test.go
@@ -70,7 +70,17 @@ func TestClient_DeleteApp(t *testing.T) {
 }
 
 func TestClient_DeployApp(t *testing.T) {
-	payload := &AppDeploy{Image: "dockerhub-image", Port: 8080, Detach: true, Message: "test message", RegistryUser: "steve", RegistrySecret: "secret"}
+	payload := &AppDeploy{
+		Image:          "dockerhub-image",
+		Port:           8080,
+		Detach:         true,
+		Message:        "test message",
+		RegistryUser:   "steve",
+		RegistrySecret: "secret",
+		Team:           "dev",
+		Framework:      "default",
+		Env:            []string{"foo=bar", "boo=baz"},
+	}
 	client, teardown := setupServer(
 		clientest.NewHandler("/apps/app/", func(w http.ResponseWriter, request *http.Request) {
 			var app AppDeployRequest
@@ -93,6 +103,10 @@ func TestClient_DeployApp(t *testing.T) {
 			if app.Registry.User != payload.RegistryUser {
 				panic(fmt.Sprintf("got %v, expected %v", app.Registry.User, payload.RegistryUser))
 			}
+			if app.AppConfig.Env[0] != payload.Env[0] {
+				panic(fmt.Sprintf("got %v, expected %v", app.AppConfig.Env[0], payload.Env[0]))
+			}
+
 			if request.Method != http.MethodPost {
 				panic(fmt.Errorf("method doesn't match, want %s, got %s", http.MethodPost, request.Method))
 			}
@@ -167,7 +181,7 @@ func TestClient_DeleteAppEnvs(t *testing.T) {
 }
 
 func TestAppToTerraformStruct(t *testing.T) {
-	input := []byte(`{"name":"terraform-app-1","platform":"","teams":["dev"],"units":[],"plan":{"name":"shipa-plan","memory":0,"swap":0,"cpushare":100,"router":"traefik"},"ip":"terraform-app-1.104.200.27.23.shipa.cloud","router":"traefik","routeropts":{},"entrypoints":[],"cluster":"ln-cl2","owner":"dev@shipa.io","pool":"test-tf-142","description":"test","deploys":0,"teamowner":"dev","lock":{"Locked":false,"Reason":"","Owner":"","AcquireDate":"0001-01-01T00:00:00Z"},"tags":["dev","sandbox"],"routers":[{"name":"traefik","opts":{},"address":"terraform-app-1.104.200.27.23.shipa.cloud","type":"traefik"}],"routingsettings":null,"dependencyfilenames":["app.yaml","app.yml","Procfile","shipa-ci.yml","shipa.yaml","shipa.yml"],"status":"created","provisioner":"kubernetes","provisionerprops":{"kubernetes":{"namespace":"shipa-test-tf-142","service_account":"app-terraform-app-1","internal_dns_name":"app-terraform-app-1.shipa-test-tf-142.svc"}}}`)
+	input := []byte(`{"name":"terraform-app-1","platform":"","teams":["dev"],"units":[],"plan":{"name":"shipa-plan","memory":0,"swap":0,"cpushare":100,"router":"traefik"},"ip":"terraform-app-1.104.200.27.23.shipa.cloud","router":"traefik","routeropts":{},"entrypoints":[],"cluster":"ln-cl2","owner":"dev@shipa.io","pool":"test-tf-142","description":"test","deploys":0,"team":"dev","lock":{"Locked":false,"Reason":"","Owner":"","AcquireDate":"0001-01-01T00:00:00Z"},"tags":["dev","sandbox"],"routers":[{"name":"traefik","opts":{},"address":"terraform-app-1.104.200.27.23.shipa.cloud","type":"traefik"}],"routingsettings":null,"dependencyfilenames":["app.yaml","app.yml","Procfile","shipa-ci.yml","shipa.yaml","shipa.yml"],"status":"created","provisioner":"kubernetes","provisionerprops":{"kubernetes":{"namespace":"shipa-test-tf-142","service_account":"app-terraform-app-1","internal_dns_name":"app-terraform-app-1.shipa-test-tf-142.svc"}}}`)
 	app := &App{}
 	if err := json.Unmarshal(input, app); err != nil {
 		t.Error(err)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,3 +25,5 @@ or
 - `host` (String)
 - `admin_email` (String, Sensitive)
 - `admin_password` (String, Sensitive)
+
+or have `SHIPA_HOST` and `SHIPA_TOKEN` set as environment variables.

--- a/docs/resources/app_deploy.md
+++ b/docs/resources/app_deploy.md
@@ -33,7 +33,10 @@ Required:
 
 Optional:
 
+- `description` (String)
 - `detach` (Boolean)
+- `env` (List of String)
+- `framework` (String)
 - `message` (String)
 - `origin` (String)
 - `port` (Number)
@@ -45,5 +48,38 @@ Optional:
 - `step_interval` (Number)
 - `step_weight` (Number)
 - `steps` (Number)
+- `tags` (List of String)
+- `team` (String)
+
+Read-Only:
+
+- `plan` (List of Object) (see [below for nested schema](#nestedatt--deploy--plan))
+- `router` (List of Object) (see [below for nested schema](#nestedatt--deploy--router))
+
+<a id="nestedatt--deploy--plan"></a>
+### Nested Schema for `deploy.plan`
+
+Read-Only:
+
+- `cpushare` (Number)
+- `default` (Boolean)
+- `memory` (Number)
+- `name` (String)
+- `org` (String)
+- `public` (Boolean)
+- `swap` (Number)
+- `teams` (List of String)
+
+
+<a id="nestedatt--deploy--router"></a>
+### Nested Schema for `deploy.router`
+
+Read-Only:
+
+- `address` (String)
+- `default` (Boolean)
+- `name` (String)
+- `opts` (Map of String)
+- `type` (String)
 
 

--- a/go.mod
+++ b/go.mod
@@ -11,16 +11,22 @@ require (
 require (
 	cloud.google.com/go v0.61.0 // indirect
 	cloud.google.com/go/storage v1.10.0 // indirect
+	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/apparentlymart/go-textseg v1.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v12 v12.0.0 // indirect
+	github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 // indirect
 	github.com/aws/aws-sdk-go v1.25.3 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/go-cmp v0.5.2 // indirect
+	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
@@ -38,10 +44,13 @@ require (
 	github.com/hashicorp/terraform-json v0.8.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.2.1 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mitchellh/cli v1.1.2 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.0.4 // indirect
@@ -49,6 +58,8 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/oklog/run v1.0.0 // indirect
+	github.com/posener/complete v1.1.1 // indirect
+	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/ulikunitz/xz v0.5.8 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/zclconf/go-cty v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -425,7 +425,6 @@ golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200523222454-059865788121 h1:rITEj+UZHYC927n8GT97eC3zrpzXdb/voyeOuVKS46o=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 h1:OH54vjqzRWmbJ62fjuhxy7AxFFgoHN0/DPc/UrL8cAs=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/shipa/resource_app.go
+++ b/shipa/resource_app.go
@@ -86,10 +86,11 @@ var (
 
 func resourceApp() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAppCreate,
-		ReadContext:   resourceAppRead,
-		UpdateContext: resourceAppUpdate,
-		DeleteContext: resourceAppDelete,
+		DeprecationMessage: "You should no longer use the app resource directly. Instead you should use the shipa_app_deploy resource which now handles app creation as well.",
+		CreateContext:      resourceAppCreate,
+		ReadContext:        resourceAppRead,
+		UpdateContext:      resourceAppUpdate,
+		DeleteContext:      resourceAppDelete,
 		Schema: map[string]*schema.Schema{
 			"app": schemaApp,
 		},

--- a/shipa/resource_app_deploy.go
+++ b/shipa/resource_app_deploy.go
@@ -3,6 +3,7 @@ package shipa
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -40,6 +41,51 @@ var (
 					Type:         schema.TypeString,
 					Optional:     true,
 					RequiredWith: []string{"deploy.0.private_image"},
+				},
+				"framework": {
+					Type:         schema.TypeString,
+					Optional:     true, // This _should_ be required in the future, but can't be yet if we are to be backward compatible
+					RequiredWith: []string{"deploy.0.team"},
+				},
+				"team": {
+					Type:         schema.TypeString,
+					Optional:     true, // This _should_ be required in the future, but can't be yet if we are to be backward compatible
+					RequiredWith: []string{"deploy.0.framework"},
+				},
+				"plan": {
+					Type:         planSchema.Type,
+					Elem:         planSchema.Elem,
+					Computed:     true,
+					RequiredWith: []string{"deploy.0.framework", "deploy.0.team"},
+				},
+				"description": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					RequiredWith: []string{"deploy.0.framework", "deploy.0.team"},
+				},
+				"router": {
+					Type:         routersSchema.Type,
+					Elem:         routersSchema.Elem,
+					Computed:     true,
+					RequiredWith: []string{"deploy.0.framework", "deploy.0.team"},
+				},
+				"tags": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					RequiredWith: []string{"deploy.0.framework", "deploy.0.team"},
+				},
+				"env": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringMatch(regexp.MustCompile("^[-._a-zA-Z][-._a-zA-Z0-9]*=.*$"), "Invalid environment variable format. A valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit, and must be followed by `=` and the desired value."),
+					},
+					RequiredWith: []string{"deploy.0.framework", "deploy.0.team"},
 				},
 				"steps": {
 					Type:     schema.TypeInt,

--- a/shipa/resource_app_env.go
+++ b/shipa/resource_app_env.go
@@ -50,10 +50,11 @@ var (
 
 func resourceAppEnv() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAppEnvCreate,
-		ReadContext:   resourceAppEnvRead,
-		UpdateContext: resourceAppEnvUpdate,
-		DeleteContext: resourceAppEnvDelete,
+		DeprecationMessage: "You should no longer use the app env resource directly. Instead you should use the shipa_app_deploy resource which now handles env config as well.",
+		CreateContext:      resourceAppEnvCreate,
+		ReadContext:        resourceAppEnvRead,
+		UpdateContext:      resourceAppEnvUpdate,
+		DeleteContext:      resourceAppEnvDelete,
 		Schema: map[string]*schema.Schema{
 			"app": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
This expands the `shipa_app_deploy` resource to send app config to the deploy API to create the app as part of the deploy, rather than needing a separate `shipa_app` resource