### PR TITLE
[SHIPA-2689] Adding default timeout of 10 minutes for shipa_app_deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHIPA_LOCAL_PROVIDER_NAMESPACE=terraform.local/local/shipa
-VERSION=0.0.11
+VERSION=0.0.12
 BINARY=terraform-provider-shipa_v${VERSION}
 default: install
 

--- a/shipa/resource_app_deploy.go
+++ b/shipa/resource_app_deploy.go
@@ -144,6 +144,9 @@ func resourceAppDeploy() *schema.Resource {
 			},
 			"deploy": schemaAppDeploy,
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Default: schema.DefaultTimeout(10 * time.Minute),
+		},
 	}
 }
 


### PR DESCRIPTION
Adding a default timeout for operations related to shipa_app_deploy resources. Default timeout is now 10 minutes.